### PR TITLE
Changing the error report

### DIFF
--- a/lib/collectMetrics.js
+++ b/lib/collectMetrics.js
@@ -1,21 +1,17 @@
 var Promise = require('bluebird');
 var phantomas = require('phantomas');
 var grunt = require('grunt');
-var errors = {
-    253: 'Phantomas configuration is not correct.',
-    254: 'Page could not be loaded.',
-    255: 'Phantomas has failed with an unknown error.'
-};
 
 module.exports = function collectMetrics (url, trials, options) {
     var metrics = [];
 
     function loadPage (fn) {
         phantomas(url, options, function (err, json) {
+
             trials--;
 
-            if (errors[err]) {
-                return grunt.fatal.fail(errors[err]);
+            if (!!err) {
+                return grunt.fail.fatal(translateErrorNumberToString(err));
             }
 
             metrics.push(json.metrics);
@@ -26,6 +22,27 @@ module.exports = function collectMetrics (url, trials, options) {
 
             loadPage(fn);
         });
+    }
+
+    function translateErrorNumberToString(error) {
+        var errorNumber = parseInt(error.toString().replace(/[^0-9]/g,'')),
+          string = '';
+
+        switch (errorNumber) {
+            case 253:
+                string = 'Phantomas configuration is not correct.';
+                break;
+            case 254:
+                string = 'Page could not be loaded.';
+                break;
+            case 254:
+                string = 'Phantomas has failed with an unknown error.';
+                break;
+            default:
+                string = 'Phantomas has failed with error number ' + errorNumber;
+        }
+
+        return string;
     }
 
     return new Promise(function (res) {


### PR DESCRIPTION
The error being reported from phantomas is Error object and not a string, in order to make the error readable.
Also, fixing grunt.fail.fatal.
